### PR TITLE
style: move slot into layout on news page

### DIFF
--- a/src/layouts/News.astro
+++ b/src/layouts/News.astro
@@ -9,7 +9,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props
 ---
 
 <Layout title={title} description={description}>
-  <article>
+  <article class="space-y-4">
     {
       heroImage && (
         <div>
@@ -26,6 +26,8 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props
         </div>
       )
     }
+    <div class="py-3 space-y-4">
+      <slot />
+    </div>
   </article>
 </Layout>
-<slot />


### PR DESCRIPTION
When creating the News preview, I noticed an error on the News layout page where the body of the markdown was displaying UNDER the footer of the page. Fixed here.